### PR TITLE
Draft Development Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM ubuntu:jammy
+
+ENV KVERSION=5.15.0-84-generic
+
+# dependencies
+RUN apt-get update && apt-get install build-essential git linux-virtual -yy
+
+# build
+COPY . /linux-avb-driver
+RUN cd linux-avb-driver && make KVERSION=$KVERSION && make install KVERSION=$KVERSION
+
+# load
+RUN modprobe -S $KVERSION snd-avb
+

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,6 @@ clean:
 install:
 	mkdir -p $(MODINSTALL)
 	cp snd-avb.ko $(MODINSTALL)
-	depmod -a
+	depmod -a $(KVERSION)
 
 endif


### PR DESCRIPTION
Good morning!

I thought I'd spike the creation of a Dockerfile which might or might not be useful for local development. (It _is_ possible to use the local sound device as a passthrough, I've explored this [here](https://github.com/znibbles/07-hardware-cafe/blob/2025aa781d01bba73eab06c899df658ca205e0df/transcripts/02-libpd-docker-install.md) a while ago.)

The build command is

```
docker buildx build -t ubuntu-avb . 
```

Currently I'm stuck at the `modprobe` step, which needs privileged access to run. But even if I run the container manually (`docker run --rm -ti --privileged ubuntu-avb`) and try to load the module, I get:

```
# modprobe -S $KVERSION snd-avb
modprobe: ERROR: could not insert 'snd_avb': Exec format error
```

dmesg output:

```
[47018.397452] module soundcore: .gnu.linkonce.this_module section size must match the kernel's built struct module size at run time
```

This _might_ have to do with the following warning during `make`:

```
Skipping BTF generation for /linux-avb-driver/snd-avb.ko due to unavailability of vmlinux
```

Which is probably due to the use of `linux-virtual` headers. So it might not be possible after all... 